### PR TITLE
Add script to fetch legacy export files to new system

### DIFF
--- a/cnxupgrade/legacy_exports.py
+++ b/cnxupgrade/legacy_exports.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2013, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+"""Command-line script to take collection ids as arguments,
+get the export files from the legacy system and rename them
+to something that cnx-archive understands
+"""
+
+import argparse
+import os.path
+import sys
+import urllib2
+
+import psycopg2
+
+from .cli import DEFAULT_PSYCOPG_CONNECTION_STRING
+
+DOWNLOAD_URL = 'http://cnx.org/content/{id}/{version}/{type}'
+
+FILENAME = '{uuid}@{version}.{ext}'
+
+GET_UUID_BY_ID_SQL = '''
+SELECT m.uuid
+FROM modules m
+WHERE m.moduleid = %s
+'''
+
+GET_LATEST_VERSION_BY_ID_SQL = '''
+SELECT m.version, m.revised
+FROM modules m
+WHERE m.moduleid = %s
+ORDER BY m.revised DESC
+LIMIT 1
+'''
+
+GET_VERSIONS_BY_ID_SQL = '''
+SELECT DISTINCT(m.version)
+FROM modules m
+WHERE m.moduleid = %s
+'''
+
+def get_export_file(moduleid, version, type, filename):
+    """Get the export file from the legacy system and store it as filename
+    """
+    url = DOWNLOAD_URL.format(id=moduleid, version=version, type=type)
+    chunksize = 8192
+    try:
+        content = urllib2.urlopen(url)
+    except urllib2.HTTPError:
+        sys.stderr.write('Unable to get "{}" from legacy system\n'.format(url))
+        return
+    print 'Downloading from "{}", saving as "{}"'.format(url, filename)
+    with open(filename, 'wb') as out_file:
+        while True:
+            piece = content.read(chunksize)
+            if not piece:
+                break # finish copying file
+            out_file.write(piece)
+
+def get_export_filename(uuid, version, extension):
+    """Return a filename for the legacy export file that cnx-archive
+    understands
+    """
+    return FILENAME.format(uuid=uuid, version=version, ext=extension)
+
+def get_export_types():
+    """Return a list of export file types available for download
+    """
+    return [
+            {'ext': 'pdf', 'type': 'pdf'},
+            {'ext': 'epub', 'type': 'epub'},
+            {'ext': 'xml', 'type': 'source'},
+            {'ext': 'zip', 'type': 'offline'},
+           ]
+
+def get_uuid(cursor, collection_id):
+    """Return the uuid for a legacy id
+    """
+    cursor.execute(GET_UUID_BY_ID_SQL, [collection_id])
+    try:
+        return cursor.fetchone()[0]
+    except (IndexError, TypeError):
+        sys.stderr.write('Unable to find collection "{}" in the database\n'
+                         .format(collection_id))
+
+def get_versions(cursor, collection_id, latest_only):
+    """Return a list of versions that we have for a collection id
+    """
+    if latest_only:
+        cursor.execute(GET_LATEST_VERSION_BY_ID_SQL, [collection_id])
+    else:
+        cursor.execute(GET_VERSIONS_BY_ID_SQL, [collection_id])
+    for result in cursor.fetchall():
+        yield result[0]
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Get export files from legacy '
+            'systems and rename them to something that cnx-archive understands')
+    parser.add_argument('--db-conn-str',
+                        default=DEFAULT_PSYCOPG_CONNECTION_STRING,
+                        help='a psycopg2 db connection string')
+    parser.add_argument('--dest', metavar='destination_directory',
+                        default='/var/www/files/',
+                        help='the directory where all the downloads should go')
+    parser.add_argument('--latest-only', dest='latest_only',
+                        action='store_true', default=True,
+                        help='download only the latest version')
+    parser.add_argument('--all-versions', dest='latest_only',
+                        action='store_false', default=False,
+                        help='download all versions')
+    parser.add_argument('collection_ids', metavar='collection_id', nargs='+',
+                        help='Collection id, e.g. col12345')
+    args = parser.parse_args(argv)
+
+    with psycopg2.connect(args.db_conn_str) as db_connection:
+        with db_connection.cursor() as cursor:
+            for collection_id in args.collection_ids:
+
+                print 'Processing collection "{}"'.format(collection_id)
+                uuid = get_uuid(cursor, collection_id)
+                if uuid is None:
+                    # skip if a collection id is not in the db
+                    continue
+
+                for version in get_versions(cursor, collection_id,
+                                            args.latest_only):
+                    for export_type in get_export_types():
+                        extension = export_type['ext']
+                        type = export_type['type']
+                        filename = get_export_filename(uuid, version, extension)
+                        get_export_file(collection_id, version, type,
+                                        os.path.join(args.dest, filename))
+
+
+if __name__ == '__main__':
+    main()

--- a/cnxupgrade/tests/test_legacy_exports.py
+++ b/cnxupgrade/tests/test_legacy_exports.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2013, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+
+import glob
+from io import BytesIO
+import os.path
+import shutil
+import sys
+import tempfile
+import unittest
+import urllib2
+
+from .test_upgrades_to_html import (
+        DB_CONNECTION_STRING,
+        postgresql_fixture, db_connect,
+        )
+
+
+class LegacyExportsTestCase(unittest.TestCase):
+    """Tests for cnx-upgrade-legacy-exports script
+    """
+    fixture = postgresql_fixture
+
+    @db_connect
+    def setUp(self, cursor):
+        self.fixture.setUp()
+
+        # set up test data
+        cursor.execute('''
+ALTER TABLE modules DISABLE TRIGGER ALL;
+INSERT INTO abstracts VALUES (1, 'sample abstracts');
+INSERT INTO modules VALUES (1, 'Collection', 'col11406', 'e79ffde3-7fb4-4af3-9ec8-df648b391597', '1.7', 'College Physics', '2013-07-31 14:07:20.342798-05', '2013-08-31 14:07:20.342798-05', 1, 11, '', '', '', NULL, NULL, 'en', '{e5a07af6-09b9-4b74-aa7a-b7510bee90b8}', '{e5a07af6-09b9-4b74-aa7a-b7510bee90b8, 1df3bab1-1dc7-4017-9b3a-960a87e706b1}', '{9366c786-e3c8-4960-83d4-aec1269ac5e5}', NULL, 'UA-XXXXX-Y', NULL, 7, 1);
+INSERT INTO modules VALUES (2, 'Collection', 'col11406', 'e79ffde3-7fb4-4af3-9ec8-df648b391597', '1.6', 'College Physics', '2013-07-31 14:07:20.342798-05', '2013-07-31 14:07:20.342798-05', 1, 11, '', '', '', NULL, NULL, 'en', '{e5a07af6-09b9-4b74-aa7a-b7510bee90b8}', '{e5a07af6-09b9-4b74-aa7a-b7510bee90b8, 1df3bab1-1dc7-4017-9b3a-960a87e706b1}', '{9366c786-e3c8-4960-83d4-aec1269ac5e5}', NULL, 'UA-XXXXX-Y', NULL, 6, 1);
+        ''')
+
+        # Mock response from legacy site
+        self.responses = ['']
+        self.response_id = -1
+        def urlopen(url):
+            self.response_id += 1
+            return BytesIO(self.responses[self.response_id])
+
+        # Patch urllib2.urlopen to return the mock responses
+        original_urlopen = urllib2.urlopen
+        urllib2.urlopen = urlopen
+        self.addCleanup(setattr, urllib2, 'urlopen', original_urlopen)
+
+        # Capture stderr
+        original_stderr = sys.stderr
+        sys.stderr = BytesIO()
+        self.addCleanup(setattr, sys, 'stderr', original_stderr)
+
+        # Capture stdout
+        original_stdout = sys.stdout
+        sys.stdout = BytesIO()
+        self.addCleanup(setattr, sys, 'stdout', original_stdout)
+
+        # Create a temporary directory for the test downloads
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir)
+
+        # Default args for the script
+        self.argv = ['--db-conn-str', DB_CONNECTION_STRING,
+                     '--dest', self.tmpdir]
+
+    def tearDown(self):
+        self.fixture.tearDown()
+
+    def call_target(self):
+        from ..legacy_exports import main
+        return main(self.argv)
+
+    def test_file_not_found(self):
+        def urlopen(url):
+            self.response_id += 1
+            if self.response_id == 0:
+                raise urllib2.HTTPError(url, 404, 'Not Found', None, None)
+            return BytesIO('asdf')
+        urllib2.urlopen = urlopen
+        self.argv += ['col11406']
+        self.call_target()
+        uuid = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
+        self.assertEqual(sys.stdout.getvalue(),
+                'Processing collection "col11406"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.7/epub", '
+                'saving as "{}/{}@1.7.epub"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.7/source", '
+                'saving as "{}/{}@1.7.xml"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.7/offline", '
+                'saving as "{}/{}@1.7.zip"\n'
+                .format(self.tmpdir, uuid, self.tmpdir, uuid, self.tmpdir, uuid))
+        self.assertEqual(sys.stderr.getvalue(),
+                'Unable to get "http://cnx.org/content/col11406/1.7/pdf" from legacy system\n')
+
+    def test_collection_not_in_db(self):
+        self.argv += ['col12345']
+        self.call_target()
+        self.assertEqual(sys.stderr.getvalue(),
+                         'Unable to find collection "col12345" in the database\n')
+
+    def test_all_versions(self):
+        uuid = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
+        self.responses = ['col11406@1.7/pdf',
+                          'col11406@1.7/epub',
+                          'col11406@1.7/xml',
+                          'col11406@1.7/zip',
+                          'col11406@1.6/pdf',
+                          'col11406@1.6/epub',
+                          'col11406@1.6/xml',
+                          'col11406@1.6/zip',
+                         ]
+        self.argv += ['--all-versions', 'col11406']
+        self.call_target()
+        self.assertEqual(sys.stdout.getvalue(),
+                'Processing collection "col11406"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.7/pdf", '
+                'saving as "{tmpdir}/{uuid}@1.7.pdf"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.7/epub", '
+                'saving as "{tmpdir}/{uuid}@1.7.epub"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.7/source", '
+                'saving as "{tmpdir}/{uuid}@1.7.xml"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.7/offline", '
+                'saving as "{tmpdir}/{uuid}@1.7.zip"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.6/pdf", '
+                'saving as "{tmpdir}/{uuid}@1.6.pdf"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.6/epub", '
+                'saving as "{tmpdir}/{uuid}@1.6.epub"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.6/source", '
+                'saving as "{tmpdir}/{uuid}@1.6.xml"\n'
+                'Downloading from "http://cnx.org/content/col11406/1.6/offline", '
+                'saving as "{tmpdir}/{uuid}@1.6.zip"\n'
+                .format(uuid=uuid, tmpdir=self.tmpdir))
+
+        # Check the files downloaded
+        files = glob.glob(os.path.join(self.tmpdir, '*'))
+        filenames = [os.path.basename(f) for f in files]
+        self.assertEqual(sorted(filenames),
+                ['{}@1.6.epub'.format(uuid),
+                 '{}@1.6.pdf'.format(uuid),
+                 '{}@1.6.xml'.format(uuid),
+                 '{}@1.6.zip'.format(uuid),
+                 '{}@1.7.epub'.format(uuid),
+                 '{}@1.7.pdf'.format(uuid),
+                 '{}@1.7.xml'.format(uuid),
+                 '{}@1.7.zip'.format(uuid)])

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     [console_scripts]
     cnx-upgrade = cnxupgrade.cli:main
     cnx-upgrade-buylinks = cnxupgrade.buylinks:main
+    cnx-upgrade-legacy-exports = cnxupgrade.legacy_exports:main
     """,
     test_suite='cnxupgrade.tests',
     )


### PR DESCRIPTION
```
$ cnx-upgrade-legacy-exports -h
usage: cnx-upgrade-legacy-exports [-h] [--db-conn-str DB_CONN_STR]
                                  [--dest destination_directory]
                                  [--latest-only] [--all-versions]
                                  collection_id [collection_id ...]

Get export files from legacy systems and rename them to something that cnx-
archive understands

positional arguments:
  collection_id         Collection id, e.g. col12345

optional arguments:
  -h, --help            show this help message and exit
  --db-conn-str DB_CONN_STR
                        a psycopg2 db connection string
  --dest destination_directory
                        the directory where all the downloads should go
  --latest-only         download only the latest version
  --all-versions        download all versions
```

Example usage:
`$ cnx-upgrade-legacy-exports --dest /var/tmp/ col11406`

This copies `col11406_1.7.epub`, `col11406_1.7_collection.xml`, `col11406_1.7.pdf`, `col11406_1.7_offline.zip` to `e79ffde3-7fb4-4af3-9ec8-df648b391597@1.7.epub`,  `e79ffde3-7fb4-4af3-9ec8-df648b391597@1.7.xml`
`e79ffde3-7fb4-4af3-9ec8-df648b391597@1.7.pdf`,  `e79ffde3-7fb4-4af3-9ec8-df648b391597@1.7.zip`

The default behavior is download latest only.
