### PR TITLE
Add --force flag to overwrite index.html in cnx-upgrade to_html

### DIFF
--- a/cnxupgrade/tests/test_cli.py
+++ b/cnxupgrade/tests/test_cli.py
@@ -68,7 +68,8 @@ class CommandLineInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.kwargs, {
             'cmmd': to_html,
             'db_conn_str': DB_CONNECTION_STRING,
-            'id_select_query': DEFAULT_ID_SELECT_QUERY})
+            'id_select_query': DEFAULT_ID_SELECT_QUERY,
+            'overwrite_html': False})
         self.assertEqual(result, 'run cnxupgrade.upgrades.to_html')
 
     def test_to_html_with_id_select_query(self):
@@ -83,7 +84,26 @@ class CommandLineInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.kwargs, {
             'cmmd': to_html,
             'db_conn_str': DB_CONNECTION_STRING,
-            'id_select_query': 'SELECT 2'})
+            'id_select_query': 'SELECT 2',
+            'overwrite_html': False})
+        self.assertEqual(result, 'run cnxupgrade.upgrades.to_html')
+
+    def test_to_html_force_overwrite_html(self):
+        # Mock to_html.cli_command
+        to_html = self.mock('to_html')
+
+        from ..upgrades.to_html import DEFAULT_ID_SELECT_QUERY
+
+        # Invoke cnx-upgrade to_html
+        result = self.call_target(['to_html', '--force'])
+
+        # Assert to_html.cli_command was called
+        self.assertEqual(self.call_count, 1)
+        self.assertEqual(self.kwargs, {
+            'cmmd': to_html,
+            'db_conn_str': DB_CONNECTION_STRING,
+            'id_select_query': DEFAULT_ID_SELECT_QUERY,
+            'overwrite_html': True})
         self.assertEqual(result, 'run cnxupgrade.upgrades.to_html')
 
     def test_v1(self):

--- a/cnxupgrade/tests/test_upgrades_to_html.py
+++ b/cnxupgrade/tests/test_upgrades_to_html.py
@@ -36,11 +36,13 @@ class ToHtmlTestCase(unittest.TestCase):
         to_html.produce_html_for_modules = f
 
         self.call_target(db_conn_str=DB_CONNECTION_STRING,
-                         id_select_query='SELECT 2')
+                         id_select_query='SELECT 2',
+                         overwrite_html=False)
 
         # Assert produce_html_for_modules is called
         self.assertEqual(self.call_count, 1)
         self.assertEqual(str(type(self.args[0])),
                          "<type 'psycopg2._psycopg.connection'>")
         self.assertEqual(self.args[1], 'SELECT 2')
+        self.assertEqual(self.args[2], False)
         self.assertEqual(self.kwargs, {})

--- a/cnxupgrade/upgrades/to_html.py
+++ b/cnxupgrade/upgrades/to_html.py
@@ -27,10 +27,12 @@ def cli_command(**kwargs):
     """The command used by the CLI to invoke the upgrade logic."""
     connection_string = kwargs['db_conn_str']
     id_select_query = kwargs['id_select_query']
+    overwrite_html = kwargs['overwrite_html']
     with psycopg2.connect(connection_string) as db_connection:
         # TODO Ideally, logging would be part of these for loops.
         # [x for x in produce_html_for_collections(db_connection)]
-        for x in produce_html_for_modules(db_connection, id_select_query):
+        for x in produce_html_for_modules(db_connection, id_select_query,
+                                          overwrite_html):
             print x
 
 
@@ -39,4 +41,7 @@ def cli_loader(parser):
     parser.add_argument('--id-select-query', default=DEFAULT_ID_SELECT_QUERY,
                         help="an SQL query that returns module_idents to " \
                              "be converted")
+    parser.add_argument('--force', dest='overwrite_html', action='store_true',
+                        default=False,
+                        help='overwrite existing HTML files in the database')
     return cli_command


### PR DESCRIPTION
Enable this flag means that the index.html will be removed before a new
one is generated.

See https://github.com/Connexions/cnx-upgrade/issues/23 and https://github.com/Connexions/cnx-archive/pull/156
