### PR TITLE
Adds the ability to resolve entities using the publicly hosted DTD files...

### DIFF
--- a/cnxupgrade/upgrades/cnxml7/utils.py
+++ b/cnxupgrade/upgrades/cnxml7/utils.py
@@ -76,7 +76,7 @@ def determine_cnxml_version(source):
 
 
 XML_PARSER_KWARGS = dict(load_dtd=True, resolve_entities=True,
-                         no_network=True, attribute_defaults=False)
+                         no_network=False, attribute_defaults=False)
 cnxml_parser = etree.XMLParser(**XML_PARSER_KWARGS)
 xml_parser = etree.XMLParser(**XML_PARSER_KWARGS)
 


### PR DESCRIPTION
Quick fix to enable the external / publicly hosted DTD for entity resolution. This is important in the upgrade of content cnxml version >=0.5.
